### PR TITLE
Removes legacy content from Blackstone

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -106,11 +106,9 @@
 #define RANDOM_EYE_COLOR "random_eye_color"
 
 //Age ranges
-#define AGE_YOUNG			"Young Adult"
 #define AGE_ADULT			"Adult"
 #define AGE_MIDDLEAGED		"Middle-Aged"
 #define AGE_OLD				"Old"
 
-#define YOUNG_AGES_LIST list(AGE_YOUNG)
-#define ALL_AGES_LIST list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-#define ADULT_AGES_LIST list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+#define ALL_AGES_LIST list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -221,10 +221,6 @@
 	var/mob/living/carbon/human/H = parent
 	var/amt2use = HUMAN_CARRY_SLOWDOWN
 	var/reqstrength = 10
-	if(ishuman(M))
-		var/mob/living/carbon/human/HM = M
-		if(HM.age == AGE_YOUNG)
-			reqstrength -= 2
 	if(H.r_grab && H.l_grab)
 		if(H.r_grab.grabbed == M)
 			if(H.l_grab.grabbed == M)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -147,8 +147,6 @@
 			var/used_sound
 			var/possible_sounds
 			var/modifier
-			if(H.age == AGE_YOUNG)
-				modifier = "young"
 			if(H.age == AGE_OLD)
 				modifier = "old"
 			if(!ignore_silent && (H.silent || !H.can_speak()))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1012,4 +1012,4 @@
 /datum/mind/proc/get_learning_boon(skill)
 	var/mob/living/carbon/human/H = current
 	var/boon = get_skill_level(skill) / 10
-	return boon 
+	return boon

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1011,6 +1011,5 @@
 
 /datum/mind/proc/get_learning_boon(skill)
 	var/mob/living/carbon/human/H = current
-	var/boon = H.age == AGE_YOUNG ? 1.2 : 1 // optional
-	boon += get_skill_level(skill) / 10
+	var/boon = get_skill_level(skill) / 10
 	return boon 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1010,4 +1010,4 @@
 
 
 /datum/mind/proc/get_learning_boon(skill)
-	return get_skill_level(skill) / 10
+	return 1 + (get_skill_level(skill) / 10)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1010,6 +1010,4 @@
 
 
 /datum/mind/proc/get_learning_boon(skill)
-	var/mob/living/carbon/human/H = current
-	var/boon = get_skill_level(skill) / 10
-	return boon
+	return get_skill_level(skill) / 10

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -135,7 +135,6 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		owner.i_know_person(MF)
 		owner.person_knows_me(MF)
 
-	var/mob/living/carbon/human/H = owner.current
 	owner.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
 	owner.current.ambushable = FALSE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -191,8 +191,6 @@ GLOBAL_LIST_EMPTY(chosen_names)
 		to_chat(user, "<font color='red'>Classes reset.</font>")
 	random_character(gender)
 	accessory = "Nothing"
-	if(age == AGE_YOUNG)
-		age = AGE_ADULT
 
 	headshot_link = null
 	customizer_entries = list()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -69,7 +69,7 @@
 	var/list/allowed_sexes = list(MALE, FEMALE)
 	var/list/allowed_races = CLOTHED_RACES_TYPES
 	var/list/allowed_patrons
-	var/list/allowed_ages = ADULT_AGES_LIST
+	var/list/allowed_ages = ALL_AGES_LIST
 
 	/// Innate skill levels unlocked at roundstart. Format is list(/datum/skill/foo = SKILL_EXP_NOVICE) with exp as an integer or as per code/_DEFINES/skills.dm
 	var/list/skills

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -8,7 +8,7 @@
 
 	f_title = "Maid"
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = ADULT_AGES_LIST
+	allowed_ages = ALL_AGES_LIST
 
 	tutorial = "Servitude unto death; your blade a charcuterie of artisanal cheeses and meat, your armor wit and classical training. You don't consider yourself a servant anymore, if anything, you're a part of the family now. You alone have raised Kings, Queens, Princesses and Princes; without you, the royals would have all starved to death."
 

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -10,7 +10,7 @@
 
 	tutorial = "The Grenzelhofts were known for their Jesters, wisemen with a tongue just as sharp as their wit. You command a position of a fool, envious of the position your superiors have upon you. Your cheap tricks and illusions of intelligence will only work for so long, and someday youll find yourself at the end of something sharper than you."
 
-	allowed_ages = ADULT_AGES_LIST
+	allowed_ages = ALL_AGES_LIST
 	spells = list(/obj/effect/proc_holder/spell/self/telljoke,/obj/effect/proc_holder/spell/self/telltragedy)
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER

--- a/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
@@ -7,7 +7,7 @@
 	spawn_positions = -1
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = ADULT_AGES_LIST
+	allowed_ages = ALL_AGES_LIST
 	outfit = /datum/outfit/job/roguetown/vagrant
 	bypass_lastclass = TRUE
 	bypass_jobban = FALSE

--- a/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = ADULT_AGES_LIST
+	allowed_ages = ALL_AGES_LIST
 	tutorial = "Some say you're a strange individual, some say you're a cheat, while some claim you're a savant in the art of sausage making. Without your skilled hands and knifework, most of the livestock around the town would be wasted. "
 
 	outfit = /datum/outfit/job/roguetown/beastmaster

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -11,7 +11,7 @@
 
 	tutorial = "The Nightmaster is technically a noble. Owner of the Whitevein Lounge, a decaying bathhouse converted into a den of low-lifes. A troublemaking rake that the others hate to tolerate."
 
-	allowed_ages = ADULT_AGES_LIST
+	allowed_ages = ALL_AGES_LIST
 	outfit = /datum/outfit/job/roguetown/nightman
 	display_order = JDO_NIGHTMASTER
 	give_bank_account = TRUE

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -9,7 +9,7 @@
 
 	allowed_races = CLOTHED_RACES_TYPES
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Your family were zealots, they scolded you with a studded belt and prayed like sinners every waking hour of the day they weren’t toiling in the fields. You escaped them by becoming a churchling, and a guaranteed education isnt so bad"
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
@@ -8,7 +8,7 @@
 
 	allowed_races = CLOTHED_RACES_TYPES
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "You have been granted the privilege of serving as a clerk in the Steward's office. You help the Steward with anything they need, and learn how coin keeps the town moving and prosperous."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Your master once saw potential in you, something you are uncertain if they still do with your recent studies. The path to using magic is something treacherous and untamed, and you are still decades away from calling yourself even a journeyman in the field. Listen and serve, and someday you will earn your hat."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 8
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Dozens of unwanted children are born in the kingdom of Psydonia every day. They sometimes make something of themselves but much more often die early in the streets."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -8,7 +8,7 @@
 	f_title = "Princess"
 	allowed_races = CLOTHED_RACES_TYPES //Maybe a system to force-pick lineage based on king and queen should be implemented.
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "You’ve never felt the gnawing of the winter, never known the bite of hunger and certainly have never known a honest day's work. You are as free as any bird in the sky, and you may revel in your debauchery for as long as your parents remain upon the throne: But someday you’ll have to grow up, and that will be the day your carelessness will cost you more than a few mammons."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 4
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Granted a comfortable life in the Lord's manor as one of his servants! You will appreciate it more and more every day as you clean the floors and are beaten for nothing."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -8,7 +8,7 @@
 
 	allowed_races = CLOTHED_RACES_TYPES
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "The Merchant has taken you under his wing to learn the arcane arts of mercantilism, numeracy, literacy, and the joy of organizing the shelves. It is mind numbing and repetitive, but at least you have a roof over your head and comfortable surroundings. Given time, perhaps you will run the town's barter."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 
 	allowed_races = CLOTHED_RACES_TYPES
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Long hours and back-breaking work wouldnt even describe a quarter of what you do in a day for your Master. Its exhausting, filthy and you dont get much freetime: but someday youll get your own smithy, and youll have TWICE as many apprentices as your master does."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	allowed_races = CLOTHED_RACES_TYPES //same shit as town guard
 	allowed_sexes = list(MALE)
-	allowed_ages = YOUNG_AGES_LIST
+	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Mom 'n' Da said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. "
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -123,9 +123,8 @@
 	if(dna?.species)
 		if(STUBBLE in dna.species.species_traits)
 			if(gender == MALE)
-				if(age != AGE_YOUNG)
-					has_stubble = TRUE
-					update_hair()
+				has_stubble = TRUE
+				update_hair()
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	if (wear_armor && head && istype(wear_armor, /obj/item/clothing) && istype(head, /obj/item/clothing))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -144,10 +144,7 @@
 			if(text_char)
 				var/path = "sound/vo/female/spch/[text_char].ogg"
 				if(gender == MALE)
-					if(age == AGE_YOUNG)
-						path = "sound/vo/male/spch/teen/[text_char].ogg"
-					else
-						path = "sound/vo/male/spch/[text_char].ogg"
+					path = "sound/vo/male/spch/[text_char].ogg"
 				if(fexists(path))
 					playsound(get_turf(src), path, 100, FALSE, -1, frequency = freq2use)
 			sleep(1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/icon_override
 	var/icon_override_m
 	var/icon_override_f
-	var/list/possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	var/list/possible_ages = ALL_AGES_LIST
 	var/sexes = 1		// whether or not the race has sexual characteristics. at the moment this is only 0 for skeletons and shadows
 	var/patreon_req = 0
 	var/max_age = 75

--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -7,7 +7,7 @@
 	desc = "In time you will learn the history of this race"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -16,7 +16,7 @@
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	attack_verb = "slash"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'
 	dam_icon = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -11,7 +11,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = TRUE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -7,7 +7,7 @@
 	desc = "In time you will learn the history of this race"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
@@ -13,7 +13,7 @@
 	skin_tone_wording = "Skin Colors"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
@@ -7,7 +7,7 @@
 	desc = "In time you will learn the history of this race"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/mob/species/moth_m.dmi'
 	limbs_icon_f = 'icons/mob/species/moth_f.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/tabaxi.dm
@@ -17,7 +17,7 @@
 	skin_tone_wording = "Fur Colors"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE, MUTCOLORS)
 	inherent_traits = list(TRAIT_NOMOBSWAP)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'
 	dam_icon = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
@@ -17,7 +17,7 @@
 	attack_verb = "slash"
 	liked_food = GROSS | MEAT | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	limbs_icon_m = 'icons/mob/species/male.dmi'
 	limbs_icon_f = 'icons/mob/species/female.dmi'
 	dam_icon = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/_dwarf.dm
@@ -14,26 +14,6 @@
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
-	var/mob/living/carbon/human/species/dwarf/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-5), OFFSET_HEAD = list(0,-5), \
-		OFFSET_FACE = list(0,-5), OFFSET_BELT = list(0,-6), OFFSET_BACK = list(0,-5), \
-		OFFSET_NECK = list(0,-5), OFFSET_MOUTH = list(0,-5), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-4), \
-		OFFSET_ID_F = list(0,-5), OFFSET_GLOVES_F = list(0,-5), OFFSET_WRISTS_F = list(0,-5), OFFSET_HANDS_F = list(0,-5), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-6), OFFSET_HEAD_F = list(0,-6), \
-		OFFSET_FACE_F = list(0,-6), OFFSET_BELT_F = list(0,-6), OFFSET_BACK_F = list(0,-6), \
-		OFFSET_NECK_F = list(0,-6), OFFSET_MOUTH_F = list(0,-6), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mds.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fds.dmi'
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.update_hair()
-		H.update_body()
-
 /datum/species/dwarf/after_creation(mob/living/carbon/C)
 	..()
 	to_chat(C, "<span class='info'>I can speak Dwarfish with ,d before my speech.</span>")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -25,7 +25,7 @@
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,YOUNGBEARD,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP,TRAIT_DRUNK_HEALING)
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/_elf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/_elf.dm
@@ -25,30 +25,6 @@
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
-	var/mob/living/carbon/human/species/elf/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-1), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-1), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,-1), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-1), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/ms.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
-
 /datum/species/elf/after_creation(mob/living/carbon/C)
 	..()
 	to_chat(C, "<span class='info'>I can speak Elfish with ,e before my speech.</span>")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -37,7 +37,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mem.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fm.dmi'
@@ -97,33 +97,6 @@
 	if(message_language.type == /datum/language/elvish)
 		return list(SPAN_DELF)
 	return message_language.spans
-
-/datum/species/elf/dark/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	..()
-	var/mob/living/carbon/human/species/elf/dark/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-2), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-2), OFFSET_HEAD = list(0,-2), \
-		OFFSET_FACE = list(0,-2), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-2), \
-		OFFSET_NECK = list(0,-2), OFFSET_MOUTH = list(0,-2), OFFSET_PANTS = list(0, -1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-2), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mems.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
-
 
 /datum/species/elf/dark/get_skin_list()
 	return list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -27,7 +27,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/met.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fm.dmi'
@@ -79,32 +79,6 @@
 		)
 	body_markings = list(
 	)
-
-/datum/species/elf/wood/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	..()
-	var/mob/living/carbon/human/species/elf/wood/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,-2), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,0), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,0), OFFSET_PANTS = list(0,0), \
-		OFFSET_SHIRT = list(0,0), OFFSET_ARMOR = list(0,0), OFFSET_HANDS = list(0,0), OFFSET_UNDIES = list(0,-2), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mets.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
 
 /datum/species/elf/wood/get_span_language(datum/language/message_language)
 	if(!message_language)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/_human.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/_human.dm
@@ -6,30 +6,6 @@
 	. = ..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 
-	var/mob/living/carbon/human/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-1), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-1), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,-1), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-1), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/ms.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
-
 /datum/species/human/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -20,7 +20,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = 1
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -23,7 +23,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mt.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fm.dmi'
@@ -68,30 +68,6 @@
 /datum/species/aasimar/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-	var/mob/living/carbon/human/species/aasimar/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-1), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-1), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,-1), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-1), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mts.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
 
 /datum/species/aasimar/after_creation(mob/living/carbon/C)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/brazillian.dm
@@ -15,7 +15,7 @@
 	use_skintones = TRUE
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/ma.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fa.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -21,7 +21,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = 1
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED)
+	possible_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -23,7 +23,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mo.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fo.dmi'
@@ -67,30 +67,6 @@
 /datum/species/halforc/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-	var/mob/living/carbon/human/species/halforc/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-1), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-1), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,-1), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-1), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mos.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fos.dmi'
-
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
 
 /datum/species/halforc/after_creation(mob/living/carbon/C)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -26,7 +26,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = list(AGE_YOUNG, AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mt.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fm.dmi'
@@ -88,30 +88,6 @@
 /datum/species/tieberian/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
 	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-	var/mob/living/carbon/human/species/tieberian/H = C
-	if(H.age == AGE_YOUNG)
-		offset_features = list(OFFSET_ID = list(0,-1), OFFSET_GLOVES = list(0,-1), OFFSET_WRISTS = list(0,-1),\
-		OFFSET_CLOAK = list(0,-1), OFFSET_FACEMASK = list(0,-1), OFFSET_HEAD = list(0,-1), \
-		OFFSET_FACE = list(0,-1), OFFSET_BELT = list(0,-1), OFFSET_BACK = list(0,-1), \
-		OFFSET_NECK = list(0,-1), OFFSET_MOUTH = list(0,-1), OFFSET_PANTS = list(0,-1), \
-		OFFSET_SHIRT = list(0,-1), OFFSET_ARMOR = list(0,-1), OFFSET_HANDS = list(0,-1), OFFSET_UNDIES = list(0,-1), \
-		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,-1), OFFSET_WRISTS_F = list(0,-1), OFFSET_HANDS_F = list(0,-2), \
-		OFFSET_CLOAK_F = list(0,-1), OFFSET_FACEMASK_F = list(0,-2), OFFSET_HEAD_F = list(0,-2), \
-		OFFSET_FACE_F = list(0,-2), OFFSET_BELT_F = list(0,-1), OFFSET_BACK_F = list(0,-2), \
-		OFFSET_NECK_F = list(0,-2), OFFSET_MOUTH_F = list(0,-2), OFFSET_PANTS_F = list(0,-1), \
-		OFFSET_SHIRT_F = list(0,-1), OFFSET_ARMOR_F = list(0,-1), OFFSET_UNDIES_F = list(0,-1))
-
-		limbs_icon_m = 'icons/roguetown/mob/bodies/m/mts.dmi'
-		limbs_icon_f = 'icons/roguetown/mob/bodies/f/fs.dmi'
-		
-		hairyness = null
-
-//		soundpack_m = new /datum/voicepack/male/young()
-		H.has_stubble = FALSE
-		H.facial_hairstyle = "None"
-		H.update_hair()
-		H.update_body()
 
 /datum/species/tieberian/after_creation(mob/living/carbon/C)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1121,16 +1121,6 @@
 	var/mob/living/L = pulledby
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if((H.age != AGE_YOUNG) && (age == AGE_YOUNG))
-			var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
-			for(var/obj/item/grabbing/G in grabbedby)
-				if(G.limb_grabbed == head)
-					if(G.grabbee == pulledby)
-						if(G.sublimb_grabbed == BODY_ZONE_PRECISE_EARS)
-							visible_message("<span class='warning'>[src] struggles to break free from [pulledby]'s grip!</span>", \
-											"<span class='warning'>I struggle against [pulledby]'s grip!</span>", null, null, pulledby)
-							to_chat(pulledby, "<span class='warning'>[src] struggles against my grip!</span>")
-							return FALSE
 		if(HAS_TRAIT(H, TRAIT_NOSEGRAB) && !HAS_TRAIT(src, TRAIT_MISSING_NOSE))
 			var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
 			for(var/obj/item/grabbing/G in grabbedby)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -65,12 +65,6 @@
 				for(var/S in H.dna.species.specstats)
 					change_stat(S, H.dna.species.specstats[S])
 		switch(H.age)
-			if(AGE_YOUNG)
-				H.virginity = TRUE
-				change_stat("strength", -2)
-				change_stat("constitution", -2)
-				change_stat("perception", 1)
-				change_stat("speed", round(rand(-1,2)))
 			if(AGE_MIDDLEAGED)
 				change_stat("speed", -1)
 				change_stat("endurance", 1)


### PR DESCRIPTION
## About The Pull Request

Removes young adult

## Why It's Good For The Game

Young adult was hastily implemented into the game so roles like prince could still be playable, this is a proper removal of teenagers (AGE_YOUNG) from the codebase so that in the future a proper height system can be implemented - Separating young adult and adult does not make much sense whatsoever.
